### PR TITLE
fix: bump jsoup to 1.23.1 (Dependabot #5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.22.2</version>
+            <version>1.23.1</version>
         </dependency>
 
         <!-- CSV -->


### PR DESCRIPTION
Bumps `org.jsoup:jsoup` from `1.22.2` to `1.23.1` to resolve Dependabot alert **#5** (Medium, jsoup `>= 1.14.3, < 1.23.1`).

- jsoup resolves to **1.23.1** (`mvn dependency:tree`)
- `mvn test` ✓ (55 tests, 0 failures)