### PR TITLE
fix: bump httpclient5 to 5.6.3 (Dependabot #6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.6.2</version>
+            <version>5.6.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bumps `org.apache.httpcomponents.client5:httpclient5` to `5.6.3` to resolve Dependabot alert **#6** (Medium, `< 5.6.3`). Test-scoped patch bump; CI runs the full suite.